### PR TITLE
fix gradle can't sync when submodules aren't available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,14 @@ hs_err_pid*
 # Gradlew #
 .gradle/
 build/
+.idea
 *.launch
 *.classpath
 *.project
 *.factorypath
 bin/
 run/
+runs/
 .settings/
 /.apt_generated/
 /.apt_generated_tests/

--- a/build.gradle
+++ b/build.gradle
@@ -2,69 +2,73 @@ import groovy.json.*
 
 gradle.afterProject { project ->
     if (project != rootProject) {
-        project.tasks.getByName("processResources") {
-            outputs.upToDateWhen { false }
-            filesMatching('pack.mcmeta') {
-                processJsonFile([description: project.mod_name + " resources", pack_format: resource_pack_format,
-                "forge:resource_pack_format": resource_pack_format, "forge:data_pack_format": data_pack_format], getFile())
-            }
-            filesMatching('META-INF/mods.toml') {
-                def lines = [
-                    'modLoader="javafml"',
-                    'loaderVersion="' + loader_version_range + '"',
-                    'issueTrackerURL="https://github.com/' + project.github_project + '/issues"',
-                    'license="' + mod_license + '"',
-                    '',
-                    '[[mods]]',
-                    '    modId="' + project.mod_id + '"',
-                    '    logoFile="' + project.mod_id + '.png"',
-                    '    version="' + project.mod_version + '"',
-                    '    displayName="' + project.mod_name + '"',
-                    '    displayURL="' + project.mod_display_url + '"',
-                    '    authors="' + project.mod_authors + '"',
-                    "    description='''" + project.mod_description + "'''",
-                    '',
-                    '[[dependencies.' + project.mod_id + ']]',
-                    '    modId="forge"',
-                    '    mandatory=true',
-                    '    versionRange="' + project.forge_version_range + '"',
-                    '    ordering="NONE"',
-                    '    side="BOTH"',
-                    '',
-                    '[[dependencies.' + project.mod_id + ']]',
-                    '    modId="minecraft"',
-                    '    mandatory=true',
-                    '    versionRange="' + project.minecraft_version_range + '"',
-                    '    ordering="NONE"',
-                    '    side="BOTH"',
-                    '',
-                ]
-                if (project.hasProperty("modDependencies")) {
-                    project.modDependencies.each {
-                        dependency -> {
-                            lines.add('[[dependencies.' + project.mod_id + ']]');
-                            dependency.each {
-                                entry -> {
-                                    if(entry.value instanceof Boolean || entry.value instanceof Number) {
-                                        lines.add('   ' + entry.key + '=' + entry.value)
-                                    } else {
-                                        lines.add('   ' + entry.key + '="' + entry.value + '"')
+        try {
+            project.tasks.getByName("processResources") {
+                outputs.upToDateWhen { false }
+                filesMatching('pack.mcmeta') {
+                    processJsonFile([description: project.mod_name + " resources", pack_format: resource_pack_format,
+                                     "forge:resource_pack_format": resource_pack_format, "forge:data_pack_format": data_pack_format], getFile())
+                }
+                filesMatching('META-INF/mods.toml') {
+                    def lines = [
+                            'modLoader="javafml"',
+                            'loaderVersion="' + loader_version_range + '"',
+                            'issueTrackerURL="https://github.com/' + project.github_project + '/issues"',
+                            'license="' + mod_license + '"',
+                            '',
+                            '[[mods]]',
+                            '    modId="' + project.mod_id + '"',
+                            '    logoFile="' + project.mod_id + '.png"',
+                            '    version="' + project.mod_version + '"',
+                            '    displayName="' + project.mod_name + '"',
+                            '    displayURL="' + project.mod_display_url + '"',
+                            '    authors="' + project.mod_authors + '"',
+                            "    description='''" + project.mod_description + "'''",
+                            '',
+                            '[[dependencies.' + project.mod_id + ']]',
+                            '    modId="forge"',
+                            '    mandatory=true',
+                            '    versionRange="' + project.forge_version_range + '"',
+                            '    ordering="NONE"',
+                            '    side="BOTH"',
+                            '',
+                            '[[dependencies.' + project.mod_id + ']]',
+                            '    modId="minecraft"',
+                            '    mandatory=true',
+                            '    versionRange="' + project.minecraft_version_range + '"',
+                            '    ordering="NONE"',
+                            '    side="BOTH"',
+                            '',
+                    ]
+                    if (project.hasProperty("modDependencies")) {
+                        project.modDependencies.each {
+                            dependency -> {
+                                lines.add('[[dependencies.' + project.mod_id + ']]');
+                                dependency.each {
+                                    entry -> {
+                                        if(entry.value instanceof Boolean || entry.value instanceof Number) {
+                                            lines.add('   ' + entry.key + '=' + entry.value)
+                                        } else {
+                                            lines.add('   ' + entry.key + '="' + entry.value + '"')
+                                        }
                                     }
                                 }
+                                lines.add('');
                             }
-                            lines.add('');
                         }
-                    }                    
-                }
-                BufferedWriter writer = new BufferedWriter(new FileWriter(file));
-                lines.each {
-                    line -> {
-                        writer.write(line)
-                        writer.newLine()
                     }
+                    BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+                    lines.each {
+                        line -> {
+                            writer.write(line)
+                            writer.newLine()
+                        }
+                    }
+                    writer.close();
                 }
-                writer.close();
             }
+        } catch (UnknownTaskException e) {
+            logger.error(e.toString())
         }
     }
 }


### PR DESCRIPTION
this performs a little try-catch when is attemped to sync and any of the submodules isn't cloned (no gradle task to run)

will works as intended, when a module is missing/task is missing will show this error on console (and keep sync/building)
![image](https://github.com/CreativeMD/ForgeMods/assets/29090346/9d608c82-78de-40f5-b5a0-5a3c51eb6776)
